### PR TITLE
Update sub method access pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 scratch.ts
 *.scratch.ts
 coverage
+.idea

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ const person = z.object({
 
 Some gaps with this approach are:
 * It is also not very extensible or script-able
-* It can result in boiler-plate and repeated code
+* It can result in boilerplate and repeated code
 * It is relatively inaccessible
 * It has little to no similarity with the zod library
 
@@ -92,7 +92,7 @@ This exposes helper methods for generating the corresponding AST nodes that map 
 import { printNode } from 'zod-factory'
 const schema = zf.object({
   name: zf.string(),
-  age: zf.numberMethods.min(zf.number(), 18),
+  age: zf.number.t.min(zf.number(), 18),
 });
 
 const result = printNode(schema); // result: z.object({ name: z.string(), age: z.number().min(18) })
@@ -100,7 +100,7 @@ const result = printNode(schema); // result: z.object({ name: z.string(), age: z
 
 Here, methods that can be accessed directly on the `zod` object can also be accessed directly on the `zf` object to generate their AST node equivalent.
 
-Methods that are accessed not-directly on zod (e.g `min`, `max`, `email` etc.) are accessibly on an `xyzMethods` key, where `xyz` is the name of the zod property they are accessible on. This could be subject to change if there is a better experience for this.
+Methods that are accessed indirectly from `z` (e.g `min`, `max`, `email` etc.) are accessibly on a `.t` key, of the name of the direct zod property. This could be subject to change if there is a better experience for this.
 
 ### `zfs` - zod-factory 'serialized'
 This API builds on top of the core, and accepts more 'serial' arguments:
@@ -238,7 +238,7 @@ export const person = z.object({
   name: z.string({
       required_error: "Name is required",
       invalid_type_error: "Name is invalid",
-    })
+    }),
   age: z.number(),
   emails: z.array(z.string().email()),
 });
@@ -259,7 +259,6 @@ For OpenApi schemas, references are resolved by replacing them with the name of 
 
 ```json
 {
-  ...,
   "components": {
     "schemas": {
       "Emoji": {
@@ -293,8 +292,7 @@ For OpenApi schemas, references are resolved by replacing them with the name of 
         }
       }  
     }
-  },
-  ...
+  }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zod-factory",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Typescript compiler API factory abstractions for creating zod validation schemas.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/playground/sources/with-zf.ts
+++ b/playground/sources/with-zf.ts
@@ -1,8 +1,8 @@
 import { zf } from "../../dist";
 
 export const expression = zf.object({
-  name: zf.stringMethods.max(zf.string(), 20),
-  age: zf.numberMethods.min(zf.number(), 18),
+  name: zf.string.t.max(zf.string(), 20),
+  age: zf.number.t.min(zf.number(), 18)
 });
 
-export const expression2 = zf.coerceMethods.string(zf.coerce());
+export const expression2 = zf.coerce.t.string(zf.coerce());

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -1,13 +1,13 @@
 import { zf, printNode } from "..";
 
 const baseExp = zf.string({ required_message: "required" });
-const minFiveExp = zf.stringMethods.min(zf.string(), 5, "min5");
-const maxTenExp = zf.stringMethods.max(zf.string(), 10, "max10");
-const nonemptyExp = zf.stringMethods.nonempty(zf.string());
-const startsWithExp = zf.stringMethods.startsWith(zf.string(), "startsWith");
-const endsWithExp = zf.stringMethods.endsWith(zf.string(), "endsWith");
-const emailExp = zf.stringMethods.email(zf.string());
-const uuidExp = zf.stringMethods.uuid(zf.string());
+const minFiveExp = zf.string.t.min(zf.string(), 5, "min5");
+const maxTenExp = zf.string.t.max(zf.string(), 10, "max10");
+const nonemptyExp = zf.string.t.nonempty(zf.string());
+const startsWithExp = zf.string.t.startsWith(zf.string(), "startsWith");
+const endsWithExp = zf.string.t.endsWith(zf.string(), "endsWith");
+const emailExp = zf.string.t.email(zf.string());
+const uuidExp = zf.string.t.uuid(zf.string());
 
 // Source: https://github.com/colinhacks/zod/blob/master/src/__tests__/string.test.ts
 const baseSchema = printNode(baseExp);

--- a/src/core/array.ts
+++ b/src/core/array.ts
@@ -1,16 +1,12 @@
-import { zodTokens, zodArrayMembers } from "../utils";
 import {
+  zodTokens,
+  zodArrayMembers,
   zodIdentifier,
   callExpressionCreatorWithTarget,
   callExpressionCreatorWithFactoryType,
-  callExpressionCreatorWithPreviousType,
-} from "../utils/ast";
+  callExpressionCreatorWithPreviousType
+} from "../utils";
 import { buildSharedZodMemberCreators } from "./shared";
-
-export const createZodArray = callExpressionCreatorWithTarget(
-  zodIdentifier,
-  zodTokens.array
-);
 
 export const arrayMemberCreators = {
   min: callExpressionCreatorWithFactoryType(zodTokens.min, zodTokens.array),
@@ -23,6 +19,17 @@ export const arrayMemberCreators = {
   nonempty: callExpressionCreatorWithFactoryType(
     zodTokens.nonempty,
     zodTokens.array
-  ),
-  ...buildSharedZodMemberCreators(zodTokens.array),
+  )
 } as const satisfies Partial<Record<keyof typeof zodArrayMembers, any>>;
+
+export const createZodArray = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.array
+);
+
+export const _array = Object.assign(createZodArray, {
+  t: Object.assign(
+    arrayMemberCreators,
+    buildSharedZodMemberCreators(zodTokens.array)
+  )
+});

--- a/src/core/boolean.ts
+++ b/src/core/boolean.ts
@@ -1,5 +1,8 @@
-import { zodTokens, zodBooleanMembers } from "../utils";
-import { callExpressionCreatorWithTarget, zodIdentifier } from "../utils/ast";
+import {
+  zodTokens,
+  callExpressionCreatorWithTarget,
+  zodIdentifier
+} from "../utils";
 import { buildSharedZodMemberCreators } from "./shared";
 
 export const createZodBoolean = callExpressionCreatorWithTarget(
@@ -7,6 +10,6 @@ export const createZodBoolean = callExpressionCreatorWithTarget(
   zodTokens.boolean
 );
 
-export const booleanMemberCreators = {
-  ...buildSharedZodMemberCreators(zodTokens.boolean),
-} as const satisfies Partial<Record<keyof typeof zodBooleanMembers, any>>;
+export const _boolean = Object.assign(createZodBoolean, {
+  t: buildSharedZodMemberCreators(zodTokens.boolean)
+});

--- a/src/core/coerce.ts
+++ b/src/core/coerce.ts
@@ -1,19 +1,24 @@
-import { zodTokens, zodCoerceMembers } from "../utils";
 import {
+  zodTokens,
+  zodCoerceMembers,
   callExpressionCreator,
   propertyAccessExpressionCreatorWithTarget,
-  zodIdentifier,
-} from "../utils/ast";
-
-export const createZodCoerce = propertyAccessExpressionCreatorWithTarget(
-  zodIdentifier,
-  zodTokens.coerce
-);
+  zodIdentifier
+} from "../utils";
 
 export const coerceMemberCreators = {
   string: callExpressionCreator(zodTokens.string),
   number: callExpressionCreator(zodTokens.number),
   boolean: callExpressionCreator(zodTokens.boolean),
   date: callExpressionCreator(zodTokens.date),
-  bigint: callExpressionCreator(zodTokens.bigint),
+  bigint: callExpressionCreator(zodTokens.bigint)
 } as const satisfies Partial<Record<keyof typeof zodCoerceMembers, any>>;
+
+export const createZodCoerce = propertyAccessExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.coerce
+);
+
+export const _coerce = Object.assign(createZodCoerce, {
+  t: coerceMemberCreators
+});

--- a/src/core/number.ts
+++ b/src/core/number.ts
@@ -1,15 +1,11 @@
-import { zodTokens, zodNumberMembers } from "../utils";
 import {
+  zodTokens,
+  zodNumberMembers,
   callExpressionCreatorWithFactoryType,
   callExpressionCreatorWithTarget,
-  zodIdentifier,
-} from "../utils/ast";
+  zodIdentifier
+} from "../utils";
 import { buildSharedZodMemberCreators } from "./shared";
-
-export const createZodNumber = callExpressionCreatorWithTarget(
-  zodIdentifier,
-  zodTokens.number
-);
 
 export const numberMemberCreators = {
   min: callExpressionCreatorWithFactoryType(zodTokens.min, zodTokens.number),
@@ -38,6 +34,17 @@ export const numberMemberCreators = {
   finite: callExpressionCreatorWithFactoryType(
     zodTokens.finite,
     zodTokens.number
-  ),
-  ...buildSharedZodMemberCreators(zodTokens.number),
+  )
 } as const satisfies Partial<Record<keyof typeof zodNumberMembers, any>>;
+
+export const createZodNumber = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.number
+);
+
+export const _number = Object.assign(createZodNumber, {
+  t: Object.assign(
+    numberMemberCreators,
+    buildSharedZodMemberCreators(zodTokens.number)
+  )
+});

--- a/src/core/object.ts
+++ b/src/core/object.ts
@@ -1,15 +1,12 @@
-import { zodTokens, zodObjectMembers } from "../utils";
 import {
+  zodTokens,
+  zodObjectMembers,
   callExpressionCreatorWithTarget,
   zodIdentifier,
-  callExpressionCreatorWithFactoryType,
-} from "../utils/ast";
+  callExpressionCreatorWithFactoryType
+} from "../utils";
 import { buildSharedZodMemberCreators } from "./shared";
 
-export const createZodObject = callExpressionCreatorWithTarget(
-  zodIdentifier,
-  zodTokens.object
-);
 export const objectMemberCreators = {
   partial: callExpressionCreatorWithFactoryType(
     zodTokens.partial,
@@ -26,6 +23,17 @@ export const objectMemberCreators = {
   nonstrict: callExpressionCreatorWithFactoryType(
     zodTokens.nonstrict,
     zodTokens.object
-  ),
-  ...buildSharedZodMemberCreators(zodTokens.object),
+  )
 } as const satisfies Partial<Record<keyof typeof zodObjectMembers, any>>;
+
+export const createZodObject = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.object
+);
+
+export const _object = Object.assign(createZodObject, {
+  t: Object.assign(
+    objectMemberCreators,
+    buildSharedZodMemberCreators(zodTokens.object)
+  )
+});

--- a/src/core/others.ts
+++ b/src/core/others.ts
@@ -1,0 +1,267 @@
+import {
+  callExpressionCreatorWithTarget,
+  zodIdentifier,
+  zodTokens
+} from "../utils";
+import { buildSharedZodMemberCreators } from "./shared";
+
+export const createZodUnion = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.union
+);
+export const _union = Object.assign(createZodUnion, {
+  t: buildSharedZodMemberCreators(zodTokens.union)
+});
+
+export const createZodEnum = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.enum
+);
+export const _enum = Object.assign(createZodEnum, {
+  t: buildSharedZodMemberCreators(zodTokens.enum)
+});
+
+export const createZodLiteral = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.literal
+);
+export const _literal = Object.assign(createZodLiteral, {
+  t: buildSharedZodMemberCreators(zodTokens.literal)
+});
+
+export const createZodPromise = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.promise
+);
+export const _promise = Object.assign(createZodPromise, {
+  t: buildSharedZodMemberCreators(zodTokens.promise)
+});
+
+export const createZodOptional = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.optional
+);
+export const _optional = Object.assign(createZodOptional, {
+  t: buildSharedZodMemberCreators(zodTokens.optional)
+});
+
+export const createZodAny = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.any
+);
+export const _any = Object.assign(createZodAny, {
+  t: buildSharedZodMemberCreators(zodTokens.any)
+});
+
+export const createZodUnknown = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.unknown
+);
+export const _unknown = Object.assign(createZodUnknown, {
+  t: buildSharedZodMemberCreators(zodTokens.unknown)
+});
+
+export const createZodBigint = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.bigint
+);
+export const _bigint = Object.assign(createZodBigint, {
+  t: buildSharedZodMemberCreators(zodTokens.bigint)
+});
+
+export const createZodDate = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.date
+);
+export const _date = Object.assign(createZodDate, {
+  t: buildSharedZodMemberCreators(zodTokens.date)
+});
+
+export const createZodFunction = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.function
+);
+export const _function = Object.assign(createZodFunction, {
+  t: buildSharedZodMemberCreators(zodTokens.function)
+});
+
+export const createZodNull = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.null
+);
+export const _null = Object.assign(createZodNull, {
+  t: buildSharedZodMemberCreators(zodTokens.null)
+});
+export const createZodUndefined = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.undefined
+);
+export const _undefined = Object.assign(createZodUndefined, {
+  t: buildSharedZodMemberCreators(zodTokens.undefined)
+});
+export const createZodNever = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.never
+);
+export const _never = Object.assign(createZodNever, {
+  t: buildSharedZodMemberCreators(zodTokens.never)
+});
+export const createZodVoid = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.void
+);
+export const _void = Object.assign(createZodVoid, {
+  t: buildSharedZodMemberCreators(zodTokens.void)
+});
+export const createZodNullable = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.nullable
+);
+export const _nullable = Object.assign(createZodNullable, {
+  t: buildSharedZodMemberCreators(zodTokens.nullable)
+});
+
+export const createZodCustom = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.custom
+);
+export const _custom = Object.assign(createZodCustom, {
+  t: buildSharedZodMemberCreators(zodTokens.custom)
+});
+export const createZodMap = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.map
+);
+export const _map = Object.assign(createZodMap, {
+  t: buildSharedZodMemberCreators(zodTokens.map)
+});
+
+export const createZodRecord = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.record
+);
+export const _record = Object.assign(createZodRecord, {
+  t: buildSharedZodMemberCreators(zodTokens.record)
+});
+
+export const createZodTuple = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.tuple
+);
+export const _tuple = Object.assign(createZodTuple, {
+  t: buildSharedZodMemberCreators(zodTokens.tuple)
+});
+export const createZodIntersection = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.intersection
+);
+export const _intersection = Object.assign(createZodIntersection, {
+  t: buildSharedZodMemberCreators(zodTokens.intersection)
+});
+
+export const createZodNan = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.nan
+);
+export const _nan = Object.assign(createZodNan, {
+  t: buildSharedZodMemberCreators(zodTokens.nan)
+});
+export const createZodOboolean = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.oboolean
+);
+export const _oboolean = Object.assign(createZodOboolean, {
+  t: buildSharedZodMemberCreators(zodTokens.oboolean)
+});
+export const createZodDiscriminatedUnion = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.discriminatedUnion
+);
+export const _discriminatedUnion = Object.assign(createZodDiscriminatedUnion, {
+  t: buildSharedZodMemberCreators(zodTokens.discriminatedUnion)
+});
+
+export const createZodInstanceOf = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.instanceof
+);
+export const _instanceOf = Object.assign(createZodInstanceOf, {
+  t: buildSharedZodMemberCreators(zodTokens.instanceof)
+});
+
+export const createZodOnumber = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.onumber
+);
+export const _onumber = Object.assign(createZodOnumber, {
+  t: buildSharedZodMemberCreators(zodTokens.onumber)
+});
+export const createZodOstring = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.ostring
+);
+export const _ostring = Object.assign(createZodOstring, {
+  t: buildSharedZodMemberCreators(zodTokens.ostring)
+});
+export const createZodNativeEnum = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.nativeEnum
+);
+export const _nativeEnum = Object.assign(createZodNativeEnum, {
+  t: buildSharedZodMemberCreators(zodTokens.nativeEnum)
+});
+
+export const createZodLazy = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.lazy
+);
+export const _lazy = Object.assign(createZodLazy, {
+  t: buildSharedZodMemberCreators(zodTokens.lazy)
+});
+export const createZodTransformer = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.transformer
+);
+export const _transformer = Object.assign(createZodTransformer, {
+  t: buildSharedZodMemberCreators(zodTokens.transformer)
+});
+
+export const createZodEffect = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.effect
+);
+export const _effect = Object.assign(createZodEffect, {
+  t: buildSharedZodMemberCreators(zodTokens.effect)
+});
+
+export const createZodPipeline = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.pipeline
+);
+export const _pipeline = Object.assign(createZodPipeline, {
+  t: buildSharedZodMemberCreators(zodTokens.pipeline)
+});
+
+export const createZodPreprocess = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.preprocess
+);
+export const _preprocess = Object.assign(createZodPreprocess, {
+  t: buildSharedZodMemberCreators(zodTokens.preprocess)
+});
+
+export const createZodSymbol = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.symbol
+);
+export const _symbol = Object.assign(createZodSymbol, {
+  t: buildSharedZodMemberCreators(zodTokens.symbol)
+});
+
+export const createZodStrictObject = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.strictObject
+);
+export const _strictObject = Object.assign(createZodStrictObject, {
+  t: buildSharedZodMemberCreators(zodTokens.strictObject)
+});

--- a/src/core/set.ts
+++ b/src/core/set.ts
@@ -1,13 +1,13 @@
-import { zodTokens, zodArrayMembers, zodSetMembers } from "../utils";
 import {
+  zodTokens,
+  zodSetMembers,
   zodIdentifier,
   callExpressionCreatorWithTarget,
-  callExpressionCreatorWithFactoryType,
-  callExpressionCreatorWithPreviousType,
-} from "../utils/ast";
+  callExpressionCreatorWithFactoryType
+} from "../utils";
 import { buildSharedZodMemberCreators } from "./shared";
 
-export const createZodArray = callExpressionCreatorWithTarget(
+export const createZodSet = callExpressionCreatorWithTarget(
   zodIdentifier,
   zodTokens.set
 );
@@ -19,6 +19,12 @@ export const setMemberCreators = {
   nonempty: callExpressionCreatorWithFactoryType(
     zodTokens.nonempty,
     zodTokens.set
-  ),
-  ...buildSharedZodMemberCreators(zodTokens.set),
+  )
 } as const satisfies Partial<Record<keyof typeof zodSetMembers, any>>;
+
+export const _set = Object.assign(createZodSet, {
+  t: Object.assign(
+    setMemberCreators,
+    buildSharedZodMemberCreators(zodTokens.set)
+  )
+});

--- a/src/core/string.ts
+++ b/src/core/string.ts
@@ -1,15 +1,11 @@
-import { zodStringMembers, zodTokens } from "../utils";
 import {
+  zodStringMembers,
+  zodTokens,
   zodIdentifier,
   callExpressionCreatorWithTarget,
-  callExpressionCreatorWithFactoryType,
-} from "../utils/ast";
+  callExpressionCreatorWithFactoryType
+} from "../utils";
 import { buildSharedZodMemberCreators } from "./shared";
-
-export const createZodString = callExpressionCreatorWithTarget(
-  zodIdentifier,
-  zodTokens.string
-);
 
 export const stringMemberCreators = {
   min: callExpressionCreatorWithFactoryType(zodTokens.min, zodTokens.string),
@@ -44,9 +40,17 @@ export const stringMemberCreators = {
   trim: callExpressionCreatorWithFactoryType(zodTokens.trim, zodTokens.string),
   ip: callExpressionCreatorWithFactoryType(zodTokens.ip, zodTokens.string),
   ulid: callExpressionCreatorWithFactoryType(zodTokens.ulid, zodTokens.string),
-  emoji: callExpressionCreatorWithFactoryType(
-    zodTokens.emoji,
-    zodTokens.string
-  ),
-  ...buildSharedZodMemberCreators(zodTokens.string),
+  emoji: callExpressionCreatorWithFactoryType(zodTokens.emoji, zodTokens.string)
 } as const satisfies Partial<Record<keyof typeof zodStringMembers, any>>;
+
+export const createZodString = callExpressionCreatorWithTarget(
+  zodIdentifier,
+  zodTokens.string
+);
+
+export const _string = Object.assign(createZodString, {
+  t: Object.assign(
+    stringMemberCreators,
+    buildSharedZodMemberCreators(zodTokens.string)
+  )
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,13 @@
-import { zodSubMemberCreators, zodDirectMemberCreators } from "./zf";
+import { zf } from "./zf";
 
-export type LazyTypeMembersByType = {
-  [K in keyof typeof zodSubMemberCreators]: keyof (typeof zodSubMemberCreators)[K];
-};
+// Source: https://time-is-life.fun/typescript-extracting-keys-of-union-type-keyof-uniontype/
+export type KeysOfUnion<T> = T extends T ? keyof T : never;
 
-export type LazyTypeMembersFlat =
-  LazyTypeMembersByType[keyof LazyTypeMembersByType];
+export type LazyTypeMembersFlat = KeysOfUnion<
+  (typeof zf)[keyof typeof zf]["t"]
+>;
 
-export type LazyDirectMemberNames = keyof typeof zodDirectMemberCreators;
+export type LazyDirectMemberNames = keyof typeof zf;
 
 export type AllLazyMembers = LazyDirectMemberNames | LazyTypeMembersFlat;
 

--- a/src/zf.ts
+++ b/src/zf.ts
@@ -1,108 +1,90 @@
+import { zodDirectMembers } from "./utils";
+import { _array, arrayMemberCreators } from "./core/array";
+import { _boolean } from "./core/boolean";
+import { _coerce, coerceMemberCreators } from "./core/coerce";
+import { _number, numberMemberCreators } from "./core/number";
+import { _object, objectMemberCreators } from "./core/object";
+import { _string, stringMemberCreators } from "./core/string";
+import { _set, setMemberCreators } from "./core/set";
 import {
-  callExpressionCreatorWithPreviousType,
-  callExpressionCreatorWithTarget,
-  propertyAccessExpressionCreatorWithTarget,
-  zodIdentifier,
-} from "./utils/ast";
-import { zodDirectMembers, zodTokens } from "./utils/constants";
-import { arrayMemberCreators } from "./core/array";
-import { booleanMemberCreators } from "./core/boolean";
-import { coerceMemberCreators } from "./core/coerce";
-import { numberMemberCreators } from "./core/number";
-import { objectMemberCreators } from "./core/object";
-import { stringMemberCreators } from "./core/string";
-import { setMemberCreators } from "./core/set";
-
-export const zodDirectMemberCreators = {
-  union: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.union),
-  enum: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.enum),
-  literal: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.literal),
-  string: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.string),
-  number: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.number),
-  boolean: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.boolean),
-  promise: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.promise),
-  object: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.object),
-  optional: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.optional),
-  array: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.array),
-  coerce: propertyAccessExpressionCreatorWithTarget(
-    zodIdentifier,
-    zodTokens.coerce
-  ),
-  any: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.any),
-  unknown: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.unknown),
-  bigint: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.bigint),
-  date: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.date),
-  function: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.function),
-  null: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.null),
-  undefined: callExpressionCreatorWithTarget(
-    zodIdentifier,
-    zodTokens.undefined
-  ),
-  never: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.never),
-  void: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.void),
-  nullable: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.nullable),
-  custom: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.custom),
-  map: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.map),
-  set: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.set),
-  record: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.record),
-  tuple: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.tuple),
-  intersection: callExpressionCreatorWithTarget(
-    zodIdentifier,
-    zodTokens.intersection
-  ),
-  nan: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.nan),
-  oboolean: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.oboolean),
-  discriminatedUnion: callExpressionCreatorWithTarget(
-    zodIdentifier,
-    zodTokens.discriminatedUnion
-  ),
-  instanceof: callExpressionCreatorWithTarget(
-    zodIdentifier,
-    zodTokens.instanceof
-  ),
-  onumber: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.onumber),
-  ostring: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.ostring),
-  nativeEnum: callExpressionCreatorWithTarget(
-    zodIdentifier,
-    zodTokens.nativeEnum
-  ),
-  lazy: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.lazy),
-  transformer: callExpressionCreatorWithTarget(
-    zodIdentifier,
-    zodTokens.transformer
-  ),
-
-  effect: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.effect),
-  pipeline: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.pipeline),
-  preprocess: callExpressionCreatorWithTarget(
-    zodIdentifier,
-    zodTokens.preprocess
-  ),
-  symbol: callExpressionCreatorWithTarget(zodIdentifier, zodTokens.symbol),
-  strictObject: callExpressionCreatorWithTarget(
-    zodIdentifier,
-    zodTokens.strictObject
-  ),
-} as const satisfies Partial<Record<keyof typeof zodDirectMembers, any>>;
-
-export const zodSubMemberCreators = {
-  object: objectMemberCreators,
-  string: stringMemberCreators,
-  number: numberMemberCreators,
-  coerce: coerceMemberCreators,
-  array: arrayMemberCreators,
-  set: setMemberCreators,
-  boolean: booleanMemberCreators,
-} as const satisfies Partial<Record<keyof typeof zodDirectMembers, any>>;
+  _any,
+  _bigint,
+  _custom,
+  _date,
+  _discriminatedUnion,
+  _effect,
+  _enum,
+  _function,
+  _instanceOf,
+  _intersection,
+  _lazy,
+  _literal,
+  _map,
+  _nan,
+  _nativeEnum,
+  _never,
+  _null,
+  _nullable,
+  _oboolean,
+  _onumber,
+  _optional,
+  _ostring,
+  _pipeline,
+  _preprocess,
+  _promise,
+  _record,
+  _strictObject,
+  _symbol,
+  _transformer,
+  _tuple,
+  _undefined,
+  _union,
+  _unknown,
+  _void
+} from "./core/others";
 
 export const zodFactory = {
-  ...zodDirectMemberCreators,
-  objectMethods: zodSubMemberCreators.object,
-  stringMethods: zodSubMemberCreators.string,
-  numberMethods: zodSubMemberCreators.number,
-  coerceMethods: zodSubMemberCreators.coerce,
-  arrayMethods: zodSubMemberCreators.array,
-  setMethods: zodSubMemberCreators.set,
-} as const;
+  string: _string,
+  number: _number,
+  boolean: _boolean,
+  object: _object,
+  array: _array,
+  coerce: _coerce,
+  set: _set,
+  union: _union,
+  enum: _enum,
+  literal: _literal,
+  promise: _promise,
+  optional: _optional,
+  any: _any,
+  unknown: _unknown,
+  bigint: _bigint,
+  date: _date,
+  function: _function,
+  null: _null,
+  undefined: _undefined,
+  never: _never,
+  void: _void,
+  nullable: _nullable,
+  custom: _custom,
+  map: _map,
+  record: _record,
+  tuple: _tuple,
+  intersection: _intersection,
+  nan: _nan,
+  oboolean: _oboolean,
+  discriminatedUnion: _discriminatedUnion,
+  instanceof: _instanceOf,
+  onumber: _onumber,
+  ostring: _ostring,
+  nativeEnum: _nativeEnum,
+  lazy: _lazy,
+  transformer: _transformer,
+  effect: _effect,
+  pipeline: _pipeline,
+  preprocess: _preprocess,
+  symbol: _symbol,
+  strictObject: _strictObject
+} as const satisfies Partial<Record<keyof typeof zodDirectMembers, any>>;
 
 export { zodFactory as zf };

--- a/src/zfl.ts
+++ b/src/zfl.ts
@@ -1,7 +1,7 @@
-import { zodDirectMemberCreators } from "./zf";
 import { zodTokens } from "./utils";
 import { zfs } from "./zfs";
 import { AllLazyMembers } from "./types";
+import { zf } from "./zf";
 
 function createLazyMember<T extends AllLazyMembers>(token: T, soFar: any[]) {
   const zodTokenKeys = Object.keys(zodTokens) as AllLazyMembers[];
@@ -13,7 +13,7 @@ function createLazyMember<T extends AllLazyMembers>(token: T, soFar: any[]) {
       (acc, curr) => {
         return {
           ...acc,
-          [curr]: createLazyMember(curr, soFar),
+          [curr]: createLazyMember(curr, soFar)
         };
       },
       { create: () => zfs(soFar) } as LazyResult
@@ -29,13 +29,11 @@ type LazyResult<T extends string = string> = {
 export function zodFactoryLazy() {
   const params: any[] = [];
 
-  const zodDirectKeys = Object.keys(
-    zodDirectMemberCreators
-  ) as (keyof typeof zodDirectMemberCreators)[];
+  const zodDirectKeys = Object.keys(zf) as (keyof typeof zf)[];
   return zodDirectKeys.reduce((acc, name) => {
     return {
       ...acc,
-      [name]: createLazyMember(name, params),
+      [name]: createLazyMember(name, params)
     };
   }, {} as Record<(typeof zodDirectKeys)[number], ReturnType<typeof createLazyMember>>);
 }

--- a/src/zfs.ts
+++ b/src/zfs.ts
@@ -2,7 +2,7 @@ import ts from "typescript";
 import { zodSharedMemberCreators } from "./core/shared";
 import { AllLazyMembers, LazyParams } from "./types";
 import { OnlyMethods } from "./utils";
-import { zf, zodSubMemberCreators } from "./zf";
+import { zf } from "./zf";
 
 export function zodFactorySerial<T extends AllLazyMembers>(
   params: LazyParams<T>
@@ -27,24 +27,20 @@ export function zodFactorySerial<T extends AllLazyMembers>(
     let methods: any;
 
     // If we don't have sub methods defined for this, fall back to the shared methods
-    if (zodSubMemberCreators[typeMethodKey]) {
-      methods = zodSubMemberCreators[typeMethodKey];
-    } else {
-      methods = zodSharedMemberCreators;
-    }
+    methods = zf[typeMethodKey]?.t || zodSharedMemberCreators;
 
     const creator = methods[currMethod as keyof typeof methods];
 
     if (!creator) {
       throw new Error(
-        `Unrecognized member '${currMethod}' on '${acc._zfType}'`
+        `Unrecognized member '${String(currMethod)}' on '${acc._zfType}'`
       );
     }
 
     //@ts-ignore
     const result = creator(acc, ...(currArgs || []));
     return result;
-  }, initialExpression as ts.Expression & { _zfType: keyof typeof zodSubMemberCreators });
+  }, initialExpression as ts.Expression & { _zfType: keyof typeof zf });
 }
 
 export { zodFactorySerial as zfs };


### PR DESCRIPTION
# Overview
This PR updates the sub method access pattern for sub methods such as `min`, `max` etc.

Previously, they were accessed in the following manner:

```typescript
const nameExpression = zf.stringMethods.max(zf.string(), 20)
```

Now, they are accessed a bit more concisely as:

```typescript
const nameExpression = zf.string.t.max(zf.string(), 20)
```


# Considerations
Another option I considered was
```typescript
const nameExpression = zf.string.max(zf.string(), 20)
```
where the method doubles as the object containing properties for its own sub methods, but this becomes a problem due to sub methods such as `.length`, which would conflict with the in-built `.length` property on functions.

The choice of `.t` is inspired by tanu.js 😃 

# Notes
The unpacked bundle-size has doubled to about ~546kb (up from ~275kb) following this change (primarily coming from the .d.ts files), and I would love to consider more options for cutting it down, especially for majority of the shared methods that do not need to be duplicated for direct members. I hypothesize that a class-based approach (similar to `zod` itself) might resolve this issue!

<img width="412" alt="Screenshot 2023-04-06 at 20 45 26" src="https://user-images.githubusercontent.com/43508242/230523748-d815a987-dfb9-486c-8bb3-f13ed131f7fe.png">

<img width="642" alt="Screenshot 2023-04-06 at 20 44 59" src="https://user-images.githubusercontent.com/43508242/230523707-d84c1079-6d86-4023-9389-50f68964563c.png">

