### PR TITLE
Change prepublish to prepublishOnly plus build in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,5 @@ jobs:
         with:
           node-version: 16
       - run: npm ci
+      - run: npm run build
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:watch": "tsc -p tsconfig.json --watch",
-    "prepublish": "rm -rf dist; npm run test; npm run build",
+    "prepublishOnly": "rm -rf dist; npm run test; npm run build",
     "test": "jest --coverage"
   },
   "keywords": [


### PR DESCRIPTION
This PR updates the `prepublish` script to `prepublishOnly` so that it does not run on `npm ci`, but only on `npm publish`.