### PR TITLE
Access type methods with of

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ An abstraction of the Typescript Compiler API factory for generating zod validat
 # Installation
 You can install `zod-factory` with NPM, Yarn, pnpm or other package managers, for example:
 ```bash
-npm install zod-factory     # NPM
-pnpm install zod-factory    # PNPM
-yarn add zod-factory        # Yarn
+npm install zod-factory     # npm
+yarn add zod-factory        # yarn
+pnpm install zod-factory    # pnpm
 ```
 
 # Usage
@@ -23,8 +23,8 @@ const result = zf.printStatements([
     "Person",
     zf.object({
       name: zf.string({ required_error: "Name is required" }),
-      age: zf.number.t.nonnegative(
-        zf.number({ required_error: "Age is required" })
+      age: zf.number.of.nonnegative(
+        zf.number.of.int(zf.number({ required_error: "Age is required" }))
       )
     })
   ),
@@ -64,17 +64,17 @@ import { z } from "zod";
 
 export const Person = z.object({
   name: z.string({ required_error: "Name is required" }),
-  age: z.number({ required_error: "Age is required" }).nonnegative(),
+  age: z.number({ required_error: "Age is required" }).int().nonnegative()
 });
 
 export const Car = z.object({
   type: z.enum(["SUV", "Sedan", "Minivan"]),
-  color: z.string().optional().default("black"),
+  color: z.string().optional().default("black")
 });
 
 export const Book = z.object({
   title: z.string().max(40),
-  author: z.string({ required_error: "Author is required" }),
+  author: z.string({ required_error: "Author is required" })
 });
 ```
 
@@ -105,7 +105,7 @@ $ ts-node "./codegen/codegen.ts" -d "sources" "with-zf:.*" "with-zfl:.*" "with-z
 ## `codegen-custom.ts`
 This generates zod validators from a "custom-format" I came up with for defining validation rules. This format is a POC for code generation from other validation specifications.
 
-To run `codegen.ts` script, run the following, pointing it to the `sources` directory with the files containing custom-format expressions:
+To use this script, run the following command with the `sources` directory containing custom-format definitions:
 ```bash
 $ cd playground
 $ ts-node "./codegen/codegen-custom.ts" -d "sources" "custom-schema:.*"
@@ -176,8 +176,7 @@ export const person = z.object({
 This script generates zod schemas from OpenAPI schema components. Similar to the above, this script
 takes the `filename:schemaNameRegex` arguments, and generates zod schemas from the schema AST node definitions in the file that match the regex.
 
-Run the script as follows, pointing it to the `sources` directory with the files containing custom-format expressions:
-
+Run the script as follows, point it to the `sources` directory with the `openapi-schema.json` file.
 ```bash
 $ cd playground
 $ ts-node "./codegen/codegen-openapi.ts" -d "sources" "openapi-schema:.*" 
@@ -240,7 +239,9 @@ export const Person = z.object({
 ```
 
 # Motivation
-The Typescript Compiler API is very powerful, and heavily featured to handle a variety of use cases, but it can also be verbose, complex, difficult to extend, "type-unsafe" and very dissimilar from `zod`'s API. `zod-factory` aims to reduce this complexity by introducing abstractions on top of the TS Compiler API to make zod code generation simple, more type-safe, scriptable, and extensible.
+The Typescript Compiler API is very powerful, and heavily featured to handle a variety of use cases, but it can also be verbose, complex, difficult to extend, "type-unsafe" and very dissimilar from `zod`'s API. 
+
+`zod-factory` aims to reduce this complexity by introducing abstractions on top of the TS Compiler API to make zod code generation simple, more type-safe, scriptable, and extensible.
 
 # Acknowledgements
 This library was birthed from an independent study course project I am undertaking with my advisor, professor Garret Morris at the University of Iowa.

--- a/playground/codegen/codegen-openapi.ts
+++ b/playground/codegen/codegen-openapi.ts
@@ -5,7 +5,7 @@ import {
   zodImport,
   printStatementsToFile,
   zfs,
-  sharedMembers,
+  zf,
   zodTokens
 } from "../../dist";
 import { parseArguments } from "./helpers";
@@ -231,7 +231,7 @@ const visitAllOf = (schema: OpenAPIV3.SchemaObject) => {
   const [first, ...rest] = expressions.filter((item) => !!item);
 
   const expression = rest.reduce((acc, curr) => {
-    return sharedMembers.and(acc, curr);
+    return zf.of.and(acc, curr);
   }, first);
 
   return expression;

--- a/playground/sources/with-zf.ts
+++ b/playground/sources/with-zf.ts
@@ -1,8 +1,8 @@
 import { zf } from "../../dist";
 
 export const expression = zf.object({
-  name: zf.string.t.max(zf.string(), 20),
-  age: zf.number.t.min(zf.number(), 18)
+  name: zf.string.of.max(zf.string(), 20),
+  age: zf.number.of.min(zf.number(), 18)
 });
 
-export const expression2 = zf.coerce.t.string(zf.coerce());
+export const expression2 = zf.coerce.of.string(zf.coerce());

--- a/playground/sources/with-zfl.ts
+++ b/playground/sources/with-zfl.ts
@@ -3,8 +3,10 @@ import { zfl } from "../../dist";
 export const expression = zfl()
   .object({
     name: zfl().string().max(20).create(),
-    age: zfl().number().min(18).create(),
+    age: zfl().number().min(18).create()
   })
   .create();
 
 export const expression2 = zfl().coerce().string().create();
+
+zfl().number();

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -1,13 +1,13 @@
 import { zf, printNode } from "..";
 
 const baseExp = zf.string({ required_message: "required" });
-const minFiveExp = zf.string.t.min(zf.string(), 5, "min5");
-const maxTenExp = zf.string.t.max(zf.string(), 10, "max10");
-const nonemptyExp = zf.string.t.nonempty(zf.string());
-const startsWithExp = zf.string.t.startsWith(zf.string(), "startsWith");
-const endsWithExp = zf.string.t.endsWith(zf.string(), "endsWith");
-const emailExp = zf.string.t.email(zf.string());
-const uuidExp = zf.string.t.uuid(zf.string());
+const minFiveExp = zf.string.of.min(zf.string(), 5, "min5");
+const maxTenExp = zf.string.of.max(zf.string(), 10, "max10");
+const nonemptyExp = zf.string.of.nonempty(zf.string());
+const startsWithExp = zf.string.of.startsWith(zf.string(), "startsWith");
+const endsWithExp = zf.string.of.endsWith(zf.string(), "endsWith");
+const emailExp = zf.string.of.email(zf.string());
+const uuidExp = zf.string.of.uuid(zf.string());
 
 // Source: https://github.com/colinhacks/zod/blob/master/src/__tests__/string.test.ts
 const baseSchema = printNode(baseExp);

--- a/src/core/array.ts
+++ b/src/core/array.ts
@@ -28,7 +28,7 @@ const createZodArray = callExpressionCreatorWithTarget(
 );
 
 export const array = Object.assign(createZodArray, {
-  t: Object.assign(
+  of: Object.assign(
     arrayMemberCreators,
     buildSharedZodMemberCreators(zodTokens.array)
   )

--- a/src/core/boolean.ts
+++ b/src/core/boolean.ts
@@ -11,5 +11,5 @@ const createZodBoolean = callExpressionCreatorWithTarget(
 );
 
 export const boolean = Object.assign(createZodBoolean, {
-  t: buildSharedZodMemberCreators(zodTokens.boolean)
+  of: buildSharedZodMemberCreators(zodTokens.boolean)
 });

--- a/src/core/coerce.ts
+++ b/src/core/coerce.ts
@@ -20,5 +20,5 @@ const createZodCoerce = propertyAccessExpressionCreatorWithTarget(
 );
 
 export const coerce = Object.assign(createZodCoerce, {
-  t: coerceMemberCreators
+  of: coerceMemberCreators
 });

--- a/src/core/number.ts
+++ b/src/core/number.ts
@@ -43,7 +43,7 @@ const createZodNumber = callExpressionCreatorWithTarget(
 );
 
 export const number = Object.assign(createZodNumber, {
-  t: Object.assign(
+  of: Object.assign(
     numberMemberCreators,
     buildSharedZodMemberCreators(zodTokens.number)
   )

--- a/src/core/object.ts
+++ b/src/core/object.ts
@@ -32,7 +32,7 @@ const createZodObject = callExpressionCreatorWithTarget(
 );
 
 export const object = Object.assign(createZodObject, {
-  t: Object.assign(
+  of: Object.assign(
     objectMemberCreators,
     buildSharedZodMemberCreators(zodTokens.object)
   )

--- a/src/core/others.ts
+++ b/src/core/others.ts
@@ -10,7 +10,7 @@ const createZodUnion = callExpressionCreatorWithTarget(
   zodTokens.union
 );
 export const union = Object.assign(createZodUnion, {
-  t: buildSharedZodMemberCreators(zodTokens.union)
+  of: buildSharedZodMemberCreators(zodTokens.union)
 });
 
 const createZodEnum = callExpressionCreatorWithTarget(
@@ -19,7 +19,7 @@ const createZodEnum = callExpressionCreatorWithTarget(
 );
 
 const enum_ = Object.assign(createZodEnum, {
-  t: buildSharedZodMemberCreators(zodTokens.enum)
+  of: buildSharedZodMemberCreators(zodTokens.enum)
 });
 
 export { enum_ as enum };
@@ -30,7 +30,7 @@ const createZodLiteral = callExpressionCreatorWithTarget(
 );
 
 export const literal = Object.assign(createZodLiteral, {
-  t: buildSharedZodMemberCreators(zodTokens.literal)
+  of: buildSharedZodMemberCreators(zodTokens.literal)
 });
 
 const createZodPromise = callExpressionCreatorWithTarget(
@@ -39,7 +39,7 @@ const createZodPromise = callExpressionCreatorWithTarget(
 );
 
 export const promise = Object.assign(createZodPromise, {
-  t: buildSharedZodMemberCreators(zodTokens.promise)
+  of: buildSharedZodMemberCreators(zodTokens.promise)
 });
 
 const createZodOptional = callExpressionCreatorWithTarget(
@@ -48,7 +48,7 @@ const createZodOptional = callExpressionCreatorWithTarget(
 );
 
 export const optional = Object.assign(createZodOptional, {
-  t: buildSharedZodMemberCreators(zodTokens.optional)
+  of: buildSharedZodMemberCreators(zodTokens.optional)
 });
 
 const createZodAny = callExpressionCreatorWithTarget(
@@ -56,7 +56,7 @@ const createZodAny = callExpressionCreatorWithTarget(
   zodTokens.any
 );
 const any_ = Object.assign(createZodAny, {
-  t: buildSharedZodMemberCreators(zodTokens.any)
+  of: buildSharedZodMemberCreators(zodTokens.any)
 });
 
 export { any_ as any };
@@ -67,7 +67,7 @@ const createZodUnknown = callExpressionCreatorWithTarget(
 );
 
 const unknown_ = Object.assign(createZodUnknown, {
-  t: buildSharedZodMemberCreators(zodTokens.unknown)
+  of: buildSharedZodMemberCreators(zodTokens.unknown)
 });
 
 export { unknown_ as unknown };
@@ -78,7 +78,7 @@ const createZodBigint = callExpressionCreatorWithTarget(
 );
 
 const bigint_ = Object.assign(createZodBigint, {
-  t: buildSharedZodMemberCreators(zodTokens.bigint)
+  of: buildSharedZodMemberCreators(zodTokens.bigint)
 });
 
 export { bigint_ as bigint };
@@ -87,8 +87,9 @@ const createZodDate = callExpressionCreatorWithTarget(
   zodIdentifier(),
   zodTokens.date
 );
-const date = Object.assign(createZodDate, {
-  t: buildSharedZodMemberCreators(zodTokens.date)
+
+export const date = Object.assign(createZodDate, {
+  of: buildSharedZodMemberCreators(zodTokens.date)
 });
 
 const createZodFunction = callExpressionCreatorWithTarget(
@@ -97,7 +98,7 @@ const createZodFunction = callExpressionCreatorWithTarget(
 );
 
 const function_ = Object.assign(createZodFunction, {
-  t: buildSharedZodMemberCreators(zodTokens.function)
+  of: buildSharedZodMemberCreators(zodTokens.function)
 });
 
 export { function_ as function };
@@ -108,7 +109,7 @@ const createZodNull = callExpressionCreatorWithTarget(
 );
 
 const null_ = Object.assign(createZodNull, {
-  t: buildSharedZodMemberCreators(zodTokens.null)
+  of: buildSharedZodMemberCreators(zodTokens.null)
 });
 
 export { null_ as null };
@@ -119,7 +120,7 @@ const createZodUndefined = callExpressionCreatorWithTarget(
 );
 
 const undefined_ = Object.assign(createZodUndefined, {
-  t: buildSharedZodMemberCreators(zodTokens.undefined)
+  of: buildSharedZodMemberCreators(zodTokens.undefined)
 });
 
 export { undefined_ as undefined };
@@ -128,8 +129,9 @@ const createZodNever = callExpressionCreatorWithTarget(
   zodIdentifier(),
   zodTokens.never
 );
+
 const never_ = Object.assign(createZodNever, {
-  t: buildSharedZodMemberCreators(zodTokens.never)
+  of: buildSharedZodMemberCreators(zodTokens.never)
 });
 export { never_ as never };
 
@@ -139,7 +141,7 @@ const createZodVoid = callExpressionCreatorWithTarget(
 );
 
 const void_ = Object.assign(createZodVoid, {
-  t: buildSharedZodMemberCreators(zodTokens.void)
+  of: buildSharedZodMemberCreators(zodTokens.void)
 });
 export { void_ as void };
 
@@ -149,7 +151,7 @@ const createZodNullable = callExpressionCreatorWithTarget(
 );
 
 export const nullable = Object.assign(createZodNullable, {
-  t: buildSharedZodMemberCreators(zodTokens.nullable)
+  of: buildSharedZodMemberCreators(zodTokens.nullable)
 });
 
 const createZodCustom = callExpressionCreatorWithTarget(
@@ -158,7 +160,7 @@ const createZodCustom = callExpressionCreatorWithTarget(
 );
 
 export const custom = Object.assign(createZodCustom, {
-  t: buildSharedZodMemberCreators(zodTokens.custom)
+  of: buildSharedZodMemberCreators(zodTokens.custom)
 });
 
 const createZodMap = callExpressionCreatorWithTarget(
@@ -166,7 +168,7 @@ const createZodMap = callExpressionCreatorWithTarget(
   zodTokens.map
 );
 export const map = Object.assign(createZodMap, {
-  t: buildSharedZodMemberCreators(zodTokens.map)
+  of: buildSharedZodMemberCreators(zodTokens.map)
 });
 
 const createZodRecord = callExpressionCreatorWithTarget(
@@ -174,7 +176,7 @@ const createZodRecord = callExpressionCreatorWithTarget(
   zodTokens.record
 );
 export const record = Object.assign(createZodRecord, {
-  t: buildSharedZodMemberCreators(zodTokens.record)
+  of: buildSharedZodMemberCreators(zodTokens.record)
 });
 
 const createZodTuple = callExpressionCreatorWithTarget(
@@ -182,7 +184,7 @@ const createZodTuple = callExpressionCreatorWithTarget(
   zodTokens.tuple
 );
 export const tuple = Object.assign(createZodTuple, {
-  t: buildSharedZodMemberCreators(zodTokens.tuple)
+  of: buildSharedZodMemberCreators(zodTokens.tuple)
 });
 
 const createZodIntersection = callExpressionCreatorWithTarget(
@@ -191,7 +193,7 @@ const createZodIntersection = callExpressionCreatorWithTarget(
 );
 
 export const intersection = Object.assign(createZodIntersection, {
-  t: buildSharedZodMemberCreators(zodTokens.intersection)
+  of: buildSharedZodMemberCreators(zodTokens.intersection)
 });
 
 const createZodNan = callExpressionCreatorWithTarget(
@@ -199,14 +201,14 @@ const createZodNan = callExpressionCreatorWithTarget(
   zodTokens.nan
 );
 export const nan = Object.assign(createZodNan, {
-  t: buildSharedZodMemberCreators(zodTokens.nan)
+  of: buildSharedZodMemberCreators(zodTokens.nan)
 });
 const createZodOboolean = callExpressionCreatorWithTarget(
   zodIdentifier(),
   zodTokens.oboolean
 );
 export const oboolean = Object.assign(createZodOboolean, {
-  t: buildSharedZodMemberCreators(zodTokens.oboolean)
+  of: buildSharedZodMemberCreators(zodTokens.oboolean)
 });
 
 const createZodDiscriminatedUnion = callExpressionCreatorWithTarget(
@@ -215,23 +217,25 @@ const createZodDiscriminatedUnion = callExpressionCreatorWithTarget(
 );
 
 export const discriminatedUnion = Object.assign(createZodDiscriminatedUnion, {
-  t: buildSharedZodMemberCreators(zodTokens.discriminatedUnion)
+  of: buildSharedZodMemberCreators(zodTokens.discriminatedUnion)
 });
 
 const createZodInstanceOf = callExpressionCreatorWithTarget(
   zodIdentifier(),
   zodTokens.instanceof
 );
-export const instanceOf = Object.assign(createZodInstanceOf, {
-  t: buildSharedZodMemberCreators(zodTokens.instanceof)
+const instanceof_ = Object.assign(createZodInstanceOf, {
+  of: buildSharedZodMemberCreators(zodTokens.instanceof)
 });
+
+export { instanceof_ as instanceof }
 
 const createZodOnumber = callExpressionCreatorWithTarget(
   zodIdentifier(),
   zodTokens.onumber
 );
 export const onumber = Object.assign(createZodOnumber, {
-  t: buildSharedZodMemberCreators(zodTokens.onumber)
+  of: buildSharedZodMemberCreators(zodTokens.onumber)
 });
 
 const createZodOstring = callExpressionCreatorWithTarget(
@@ -239,7 +243,7 @@ const createZodOstring = callExpressionCreatorWithTarget(
   zodTokens.ostring
 );
 export const ostring = Object.assign(createZodOstring, {
-  t: buildSharedZodMemberCreators(zodTokens.ostring)
+  of: buildSharedZodMemberCreators(zodTokens.ostring)
 });
 
 const createZodNativeEnum = callExpressionCreatorWithTarget(
@@ -247,7 +251,7 @@ const createZodNativeEnum = callExpressionCreatorWithTarget(
   zodTokens.nativeEnum
 );
 export const nativeEnum = Object.assign(createZodNativeEnum, {
-  t: buildSharedZodMemberCreators(zodTokens.nativeEnum)
+  of: buildSharedZodMemberCreators(zodTokens.nativeEnum)
 });
 
 const createZodLazy = callExpressionCreatorWithTarget(
@@ -255,14 +259,14 @@ const createZodLazy = callExpressionCreatorWithTarget(
   zodTokens.lazy
 );
 export const lazy = Object.assign(createZodLazy, {
-  t: buildSharedZodMemberCreators(zodTokens.lazy)
+  of: buildSharedZodMemberCreators(zodTokens.lazy)
 });
 const createZodTransformer = callExpressionCreatorWithTarget(
   zodIdentifier(),
   zodTokens.transformer
 );
 export const transformer = Object.assign(createZodTransformer, {
-  t: buildSharedZodMemberCreators(zodTokens.transformer)
+  of: buildSharedZodMemberCreators(zodTokens.transformer)
 });
 
 const createZodEffect = callExpressionCreatorWithTarget(
@@ -270,7 +274,7 @@ const createZodEffect = callExpressionCreatorWithTarget(
   zodTokens.effect
 );
 export const effect = Object.assign(createZodEffect, {
-  t: buildSharedZodMemberCreators(zodTokens.effect)
+  of: buildSharedZodMemberCreators(zodTokens.effect)
 });
 
 const createZodPipeline = callExpressionCreatorWithTarget(
@@ -279,7 +283,7 @@ const createZodPipeline = callExpressionCreatorWithTarget(
 );
 
 export const pipeline = Object.assign(createZodPipeline, {
-  t: buildSharedZodMemberCreators(zodTokens.pipeline)
+  of: buildSharedZodMemberCreators(zodTokens.pipeline)
 });
 
 const createZodPreprocess = callExpressionCreatorWithTarget(
@@ -287,7 +291,7 @@ const createZodPreprocess = callExpressionCreatorWithTarget(
   zodTokens.preprocess
 );
 export const preprocess = Object.assign(createZodPreprocess, {
-  t: buildSharedZodMemberCreators(zodTokens.preprocess)
+  of: buildSharedZodMemberCreators(zodTokens.preprocess)
 });
 
 const createZodSymbol = callExpressionCreatorWithTarget(
@@ -295,7 +299,7 @@ const createZodSymbol = callExpressionCreatorWithTarget(
   zodTokens.symbol
 );
 export const symbol = Object.assign(createZodSymbol, {
-  t: buildSharedZodMemberCreators(zodTokens.symbol)
+  of: buildSharedZodMemberCreators(zodTokens.symbol)
 });
 
 const createZodStrictObject = callExpressionCreatorWithTarget(
@@ -303,5 +307,5 @@ const createZodStrictObject = callExpressionCreatorWithTarget(
   zodTokens.strictObject
 );
 export const strictObject = Object.assign(createZodStrictObject, {
-  t: buildSharedZodMemberCreators(zodTokens.strictObject)
+  of: buildSharedZodMemberCreators(zodTokens.strictObject)
 });

--- a/src/core/set.ts
+++ b/src/core/set.ts
@@ -23,7 +23,7 @@ const setMemberCreators = {
 } as const satisfies Partial<Record<keyof typeof zodSetMembers, any>>;
 
 const set_ = Object.assign(createZodSet, {
-  t: Object.assign(
+  of: Object.assign(
     setMemberCreators,
     buildSharedZodMemberCreators(zodTokens.set)
   )

--- a/src/core/shared.ts
+++ b/src/core/shared.ts
@@ -46,4 +46,4 @@ export function buildSharedZodMemberCreators<
   } as const satisfies Partial<Record<keyof typeof zodSharedMembers, any>>;
 }
 
-export const sharedMembers = buildSharedZodMemberCreators();
+export const of = buildSharedZodMemberCreators();

--- a/src/core/string.ts
+++ b/src/core/string.ts
@@ -49,7 +49,7 @@ const createZodString = callExpressionCreatorWithTarget(
 );
 
 const string_ = Object.assign(createZodString, {
-  t: Object.assign(
+  of: Object.assign(
     stringMemberCreators,
     buildSharedZodMemberCreators(zodTokens.string)
   )

--- a/src/external.ts
+++ b/src/external.ts
@@ -1,5 +1,5 @@
-import { sharedMembers } from "./core/shared";
-export { sharedMembers };
+import { of } from "./core/shared";
+export { of };
 export * from "./utils/external";
 export * from "./helpers";
 export * from "./core/external";

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,7 +1,7 @@
 import ts from "typescript";
 import { zodTokens } from "./utils";
 import { ZfMembers, LazyParams, LazyResult } from "./types";
-import { sharedMembers } from "./core/shared";
+import { of } from "./core/shared";
 import * as core from "./core/external";
 
 export function zfs<T extends ZfMembers>(params: LazyParams<T>) {
@@ -22,10 +22,8 @@ export function zfs<T extends ZfMembers>(params: LazyParams<T>) {
 
     const typeMethodKey = `${acc._zfType}` as const;
 
-    let methods: any;
-
     // If we don't have sub methods defined for this, fall back to the shared methods
-    methods = core[typeMethodKey]?.t || sharedMembers;
+    const methods = core[typeMethodKey]?.of || of;
 
     const creator = methods[currMethod as keyof typeof methods];
 
@@ -67,5 +65,5 @@ export function zfl() {
       ...acc,
       [name]: addMember(name, params)
     };
-  }, {} as Record<(typeof zodDirectKeys)[number], ReturnType<typeof addMember>>);
+  }, {} as Record<keyof typeof core, ReturnType<typeof addMember>>);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ import ts from "typescript";
 export type KeysOfUnion<T> = T extends T ? keyof T : never;
 
 export type FlatTypeMembers = KeysOfUnion<
-  (typeof core)[keyof typeof core]["t"]
+  (typeof core)[keyof typeof core]["of"]
 >;
 
 export type DirectMembers = keyof typeof core;


### PR DESCRIPTION
Updates the access pattern for type members/methods from `t` to `of`, changing from #9 

For example:
```typescript
const age = zf.number.of.nonnegative(
        zf.number.of.int(zf.number())
      )

// result: z.number().int().nonnegative()
```

For shared sub methods, they are accessible on `zf.of`, For example:

```typescript
const x = zf.of.or(zf.string(), zf.number())

// result: z.string().or(z.number())
```